### PR TITLE
Added a qualifier to query to exclude draft PRs

### DIFF
--- a/pr_counts.js
+++ b/pr_counts.js
@@ -7,7 +7,7 @@ const args = minimist(process.argv.slice(2))
 const puts = console.log;
 
 var octokit = new Octokit({ auth() {return `token ${args.k}`}});
-var query = octokit.search.issuesAndPullRequests({q: "is:open+is:pr+archived:false+user:paymentspring+-label:blocked+-label:WIP"});
+var query = octokit.search.issuesAndPullRequests({q: "is:open+is:pr+archived:false+draft:false+user:paymentspring+-label:blocked+-label:WIP"});
 
 // a bit sloppy, but build up the output object as we go
 var output = {};


### PR DESCRIPTION
Added a qualifier (draft:false) to query to exclude draft PRS, from documentation found here: https://help.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-for-draft-pull-requests

**PivotalTracker**
https://www.pivotaltracker.com/n/projects/2213257/stories/167977499

**RSpec (just kidding)**
I had a draft PR with a 'WIP' label, so I ran the script and got 18. I took off the 'WIP' label and got 19. I put the 'draft:false' qualifier in the query, and then I was back to 18.